### PR TITLE
Disable remote consul version checks

### DIFF
--- a/jobs/consul/templates/consul/agent.json.erb
+++ b/jobs/consul/templates/consul/agent.json.erb
@@ -28,7 +28,8 @@
     rejoin_after_leave: true,
     ports: {
       dns: 53
-    }
+    },
+    disable_update_check: true
   }
 
   if ssl_ca and ssl_cert and ssl_key


### PR DESCRIPTION
Won't be able to check in firewalled environments anyway, and I don't think it's particularly useful when it's managed by BOSH release versioning. Also, I prefer not to be pinging external services unless it's necessary.