### PR TITLE
Only include the current consul version in packaged blobs

### DIFF
--- a/packages/consul/spec
+++ b/packages/consul/spec
@@ -2,4 +2,4 @@
 name: consul
 dependencies: []
 files:
-- consul/*linux_amd64.zip
+- consul/consul-0.5.0_linux_amd64.zip


### PR DESCRIPTION
I know they're only 6 MBs or so, but I still like avoiding packaging unused files.