### PR TITLE
Upgrade consul-template to v0.9.0

### DIFF
--- a/packages/consul-template/packaging
+++ b/packages/consul-template/packaging
@@ -7,5 +7,5 @@ set -u # report the usage of uninitialized variables
 
 mkdir -p $BOSH_INSTALL_TARGET/bin
 
-tar xfz consul-template/consul-template_0.6.0_linux_amd64.tar.gz
-cp -a consul-template_0.6.0_linux_amd64/* $BOSH_INSTALL_TARGET/bin
+tar xfz consul-template/consul-template_0.9.0_linux_amd64.tar.gz
+cp -a consul-template_0.9.0_linux_amd64/* $BOSH_INSTALL_TARGET/bin

--- a/packages/consul-template/spec
+++ b/packages/consul-template/spec
@@ -2,4 +2,4 @@
 name: consul-template
 dependencies: []
 files:
-- consul-template/consul-template_0.6.0_linux_amd64.tar.gz
+- consul-template/consul-template_0.9.0_linux_amd64.tar.gz


### PR DESCRIPTION
I'm not sure your package upgrade process, but I wanted some >0.6.0 features and bug fixes. Here's the PR if you're interested (otherwise let me know what you prefer for this sort of thing, for future reference). FYI, the [consul-template release](https://github.com/hashicorp/consul-template/releases) page indicates there were breaking changes in 0.7.0 related to SSL and authentication.

Reminder you would need to run the following with this...

    $ wget -O blobs/consul-template/consul-template_0.9.0_linux_amd64.tar.gz https://github.com/hashicorp/consul-template/releases/download/v0.9.0/consul-template_0.9.0_linux_amd64.tar.gz
    $ bosh upload blobs