### PR TITLE
Respect consul.default_recursor property

### DIFF
--- a/jobs/consul/templates/consul/agent.json.erb
+++ b/jobs/consul/templates/consul/agent.json.erb
@@ -46,7 +46,7 @@
   if (networks = spec.networks.methods(false)) && dns = spec.networks.send(networks.first).dns
     config[:recursor] = dns.first
   else
-    config[:recursor] = '8.8.8.8'
+    config[:recursor] = p('consul.default_recursor')
   end
 
   if join_hosts


### PR DESCRIPTION
Was hard-coded, although a property existed for it.