### PR TITLE
Refactor join_host/advertise_addr

### DIFF
--- a/jobs/consul/spec
+++ b/jobs/consul/spec
@@ -20,8 +20,6 @@ properties:
   consul.user:
     description: User that consul is ran under
     default: vcap
-  consul.cluster.join_host:
-    description: Hostname/IP for initial cluster node for other consul servers to join.
   consul.cluster.join_hosts:
     description: Hostnames/IPs representing all initial consul servers. Use this or consul.cluster.join_host / consul.cluster.size
   consul.cluster.size:
@@ -46,6 +44,8 @@ properties:
     description: A key to encrypt the traffic between the consul agents (use consul keygen)
   consul.client_addr:
     description: The IP to use for client communication
+  consul.advertise_addr:
+    description: Override IP to advertise to other nodes in the cluster (defaults to networks.apps, then 0.0.0.0)
 
   networks.apps:
     description: Deployment's internal name for the network interface to discover own IP

--- a/jobs/consul/templates/consul/agent.json.erb
+++ b/jobs/consul/templates/consul/agent.json.erb
@@ -1,13 +1,17 @@
 <%
   require 'json'
 
-  my_ip = spec.networks.send(properties.networks.apps).ip
-  my_host = spec.networks.send(properties.networks.apps).dns_record_name
-  join_hosts = p('consul.cluster.join_hosts', nil)
-  join_host = p('consul.cluster.join_host', nil)
+  join_hosts = p('consul.cluster.join_hosts', [])
   cluster_size = p('consul.cluster.size', nil)
-  is_inital_leader = join_host && (join_host == my_host || join_host == my_ip)
-  client_addr = p('consul.client_addr', '0.0.0.0')
+  is_inital_leader = (1 == join_hosts.length) && ('127.0.0.1' == join_hosts[1])
+
+  advertise_addr = nil
+
+  if p('consul.advertise_addr', nil)
+    advertise_addr = p('consul.advertise_addr')
+  elsif p('networks.apps', nil)
+    advertise_addr = spec.networks.send(properties.networks.apps).ip
+  end
 
   ssl_ca = p("consul.ssl_ca", nil)
   ssl_cert = p("consul.ssl_cert", nil)
@@ -18,8 +22,8 @@
     ui_dir: '/var/vcap/packages/consul-ui',
     node_name: "#{spec.deployment}-#{name}-#{index}",
     bind_addr: '0.0.0.0',
-    client_addr: client_addr,
-    advertise_addr: my_ip,
+    client_addr: p('consul.client_addr', '0.0.0.0'),
+    advertise_addr: advertise_addr,
     domain: 'consul',
     leave_on_terminate: false,
     log_level: 'INFO',
@@ -50,13 +54,9 @@
     config[:recursor] = p('consul.default_recursor')
   end
 
-  if join_hosts
-    config[:start_join] = join_hosts
-    config[:retry_join] = join_hosts
-    config[:bootstrap_expect] = cluster_size
-  elsif join_host and cluster_size
-    config[:start_join] = [join_host] unless is_inital_leader
-    config[:retry_join] = [join_host] unless is_inital_leader
+  if join_hosts and cluster_size
+    config[:start_join] = join_hosts unless is_inital_leader
+    config[:retry_join] = join_hosts unless is_inital_leader
     config[:bootstrap_expect] = cluster_size
   end
 %>


### PR DESCRIPTION
Sorry if I'm causing PR-fatigue (thanks for the other merges and feedback). I'm sending this one more for discussion, not necessarily with the expectation of it being merged. Started out as a plain issue, but then it felt complicated without code to reference.

First change is about `join_hosts` vs `join_host`. I had to go looking into `agent.json.erb` to figure out how to configure it to make it work on a standalone job for testing. It seems like it makes more sense to have a single property (`join_hosts`). So, rather than make a dependency on hard-coding the job's IP, I just have it checking whether `127.0.0.1` is used as the host.

The other change (and main motivation for the former) has to do with `network.apps`. I'm not using this on CF, so it's not already set or anything. And in my case, I want to be able to deploy this to multiple jobs in different availability zones (networks) and don't want to be maintaining the different `network.apps` property for each job. So, the other part of this diff makes that property optional defaulting to consul's own default advertise behavior.

I'm kind of assuming you have some deployments where these changes don't really make sense. If that's true, I'm wondering if you can advise me on a better implementation which will both 1) help me avoid configuring network configuration which could be defaulted in my jobs and 2) be something that can be merged back here for others.

Thanks!