### PR TITLE
Create consul blob dir in update script

### DIFF
--- a/update
+++ b/update
@@ -5,6 +5,7 @@ CONSUL_TARBALL_DIR=blobs/consul
 CONSUL_TARBALL_FILE=$CONSUL_TARBALL_DIR/consul-${CONSUL_VERSION}_linux_amd64.zip
 
 if [ ! -f $CONSUL_TARBALL_FILE ]; then
+  mkdir -p $CONSUL_TARBALL_DIR
   echo "Downloading consul version $CONSUL_VERSION tarball"
   wget https://dl.bintray.com/mitchellh/consul/${CONSUL_VERSION}_linux_amd64.zip -O $CONSUL_TARBALL_FILE
 else


### PR DESCRIPTION
When running `./update` for the first time after a  `git clone`, it fails because it tries to `wget` the consul blob into `./blobs/consul`, which doesn't exist. The script should create it.