### PR TITLE
Make leave_on_terminate configurable

### DIFF
--- a/jobs/consul/spec
+++ b/jobs/consul/spec
@@ -46,6 +46,9 @@ properties:
     description: A key to encrypt the traffic between the consul agents (use consul keygen)
   consul.client_addr:
     description: The IP to use for client communication
+  consul.leave_on_terminate:
+    description: If enabled, gracefully leave the cluster when the process shuts down.
+    default: false
 
   networks.apps:
     description: Deployment's internal name for the network interface to discover own IP

--- a/jobs/consul/templates/consul/agent.json.erb
+++ b/jobs/consul/templates/consul/agent.json.erb
@@ -21,7 +21,7 @@
     client_addr: client_addr,
     advertise_addr: my_ip,
     domain: 'consul',
-    leave_on_terminate: false,
+    leave_on_terminate: p('consul.leave_on_terminate'),
     log_level: 'INFO',
     domain: p('consul.domain', 'consul'),
     server: p('consul.server', true),


### PR DESCRIPTION
Allow consul's [`leave_on_terminate` setting](https://www.consul.io/docs/agent/options.html#leave_on_terminate) to be configured with a new `consul.leave_on_terminate` property.

There can be significant cluster complications when a consul server changes IP address. Obviously can happen on `dynamic` networks, but also when manually shuffling IPs around. Affected log messages end up looking like the following on the leader every ~13s, and cleaning it up is currently an unfortunate, manual process:

    2015/06/21 03:02:40 [ERR] raft: Failed to heartbeat to 192.0.2.101:8300: dial tcp 192.0.2.101:8300: no route to host
    2015/06/21 03:04:00 [ERR] raft: Failed to AppendEntries to 192.0.2.101:8300: dial tcp 192.0.2.101:8300: no route to host

Details are further documented upstream at hashicorp/consul#457. This property would at least allow clusters to be prepped for these sorts of situations to handle it cleanly.