### PR TITLE
add override config hash option

### DIFF
--- a/jobs/consul/spec
+++ b/jobs/consul/spec
@@ -47,5 +47,8 @@ properties:
   consul.client_addr:
     description: The IP to use for client communication
 
+  consul.agent_config:
+    description: override hash for the consul agent.json configuration
+
   networks.apps:
     description: Deployment's internal name for the network interface to discover own IP

--- a/jobs/consul/templates/consul/agent.json.erb
+++ b/jobs/consul/templates/consul/agent.json.erb
@@ -8,6 +8,7 @@
   cluster_size = p('consul.cluster.size', nil)
   is_inital_leader = join_host && (join_host == my_host || join_host == my_ip)
   client_addr = p('consul.client_addr', '0.0.0.0')
+  agent_config = p('consul.agent_config', nil)
 
   ssl_ca = p("consul.ssl_ca", nil)
   ssl_cert = p("consul.ssl_cert", nil)
@@ -20,7 +21,6 @@
     bind_addr: '0.0.0.0',
     client_addr: client_addr,
     advertise_addr: my_ip,
-    domain: 'consul',
     leave_on_terminate: false,
     log_level: 'INFO',
     domain: p('consul.domain', 'consul'),
@@ -58,6 +58,13 @@
     config[:start_join] = [join_host] unless is_inital_leader
     config[:retry_join] = [join_host] unless is_inital_leader
     config[:bootstrap_expect] = cluster_size
+  end
+
+  if agent_config
+    # symbolize hash keys, merge to config, remove nil values
+    agent_config = agent_config.inject({}) { |m,(k,v)| m[k.to_sym] = v; m }
+    config.merge!(agent_config)
+    config = config.delete_if { |k,v| v.nil? }
   end
 %>
 


### PR DESCRIPTION
Adds the optional property `consul.agent_config`, which allows to override values in the agent config hash. 
We need it to be able to add several new values to the config (`datacenter`, `acls`, etc), override certain previous ones (`bind_addr`, etc) and even entirely remove existing ones (`advertise_addr`, `client_addr`, etc).

Here's an example from our manifest we are using:
```yaml
    consul:
      server: false
      encrypt: super-secret
      cluster:
        join_hosts:
          - 1.2.3.1
          - 1.2.3.2
          - 1.2.3.3
      agent_config:
        datacenter: ch-eu-1
        acl_datacenter: fr-eu-5
        acl_token: abc-xyz
        bind_addr: 1.2.3.99
        advertise_addr: ~
        client_addr: ~
        bootstrap_expect: ~
```

@byllc Would it be possible to increase the consul version used from 0.5.0 to 0.5.2 when creating a new release?