### PR TITLE
Add the resolvconf_override property

### DIFF
--- a/jobs/consul/spec
+++ b/jobs/consul/spec
@@ -25,8 +25,11 @@ properties:
   consul.join_hosts:
     description: Hostnames/IPs representing all initial consul servers. Use this or consul.join_host / consul.size
   consul.default_recursor:
-    description: DNS recursor to use if BOSH not provising DNS
+    description: DNS recursor to use if BOSH not providing DNS
     default: 8.8.8.8
+  consul.resolvconf_override:
+    description: Force the host to use only the local consul agent for dns.
+    default: false
 
   consul.ssl_ca:
     description: "The content of the ca file"

--- a/jobs/consul/templates/bin/consul_ctl
+++ b/jobs/consul/templates/bin/consul_ctl
@@ -19,13 +19,13 @@ case $1 in
 
     setcap cap_net_bind_service=+ep $(readlink -nf /var/vcap/packages/consul/bin/consul)
 
+    <% if p("consul.resolvconf_override") == true %>
+    echo "nameserver 127.0.0.1" > /run/resolvconf/resolv.conf
+    resolvconf -u
+    <% else %>
     if ! grep -q 127.0.0.1 /etc/resolv.conf; then
       sed -i -e '1i nameserver 127.0.0.1' /etc/resolv.conf
     fi
-
-    <% if p("consul.resolvconf_override") == true %>
-      resolvconf --disable-updates
-      echo "nameserver 127.0.0.1" > /etc/resolv.conf
     <% end %>
 
     mkdir -p /var/vcap/data/consul

--- a/jobs/consul/templates/bin/consul_ctl
+++ b/jobs/consul/templates/bin/consul_ctl
@@ -23,6 +23,11 @@ case $1 in
       sed -i -e '1i nameserver 127.0.0.1' /etc/resolv.conf
     fi
 
+    <% if p("consul.resolvconf_override") == true %>
+      resolvconf --disable-updates
+      echo "nameserver 127.0.0.1" > /etc/resolv.conf
+    <% end %>
+
     mkdir -p /var/vcap/data/consul
     chown <%= user %>:<%= user %> /var/vcap/data/consul
     config_dir="-config-dir /var/vcap/data/consul "

--- a/jobs/consul/templates/bin/consul_ctl
+++ b/jobs/consul/templates/bin/consul_ctl
@@ -20,8 +20,7 @@ case $1 in
     setcap cap_net_bind_service=+ep $(readlink -nf /var/vcap/packages/consul/bin/consul)
 
     <% if p("consul.resolvconf_override") == true %>
-    echo "nameserver 127.0.0.1" > /run/resolvconf/resolv.conf
-    resolvconf -u
+    echo "nameserver 127.0.0.1" > /etc/resolv.conf
     <% else %>
     if ! grep -q 127.0.0.1 /etc/resolv.conf; then
       sed -i -e '1i nameserver 127.0.0.1' /etc/resolv.conf


### PR DESCRIPTION
This adds the optional ```resolvconf_override``` property for forcing the host to use **only** the local consul agent for dns.

This is especially useful when using this bosh release with cloudfoundry. When cf warden starts containers, the container's /etc/resolv.conf is based on the host system's /etc/resolv.conf. If the DEAs resolv.conf is exactly:
```
nameserver 127.0.0.1
```
then it configures all warden containers to use the DEA's host ip for dns.
(Code that makes this work in warden can be found here: https://github.com/cloudfoundry/warden/blob/master/warden/root/linux/skeleton/setup.sh#L111)

This prop defaults to false.

Example manifest.
```
consul:
    server: false
    domain: cf.internal
    join_hosts: <redacted>
    resolvconf_override: true
    agent_config:
      log_level: INFO
      addresses:
        dns: 0.0.0.0
    ssl_ca: <redacted>
    ssl_cert: <redacted>
    ssl_key: <redacted>
```