### PR TITLE
Fix the aws deployment template

### DIFF
--- a/templates/infrastructure-aws.yml
+++ b/templates/infrastructure-aws.yml
@@ -15,7 +15,7 @@ jobs:
     persistent_disk: (( grab meta.persistent_disk ))
     properties:
       consul:
-        join_host: (( string "0.consul-z1.consul1." meta.environment "." meta.dns_root ))
+        join_host: (( concat "0.consul-z1.consul1." meta.environment "." meta.dns_root ))
 
 compilation:
   cloud_properties:


### PR DESCRIPTION
Since the "aws_ec2" option was renamed to "aws", its corresponding infrastructure file needed to be renamed too.  Also, changed the incorrect "string" directive to "concat".