### PR TITLE
Enable TLS on http port

### DIFF
--- a/jobs/consul/templates/consul/agent.json.erb
+++ b/jobs/consul/templates/consul/agent.json.erb
@@ -39,6 +39,8 @@
     config[:ca_file] = '/var/vcap/jobs/consul/consul/ca.cert'
     config[:cert_file] = '/var/vcap/jobs/consul/consul/consul.cert'
     config[:key_file] = '/var/vcap/jobs/consul/consul/consul.key'
+    config[:ports][:https] = 8500
+    config[:ports][:http] = -1
   end
 
   if p('consul.encrypt', nil)


### PR DESCRIPTION
This PR is to enable TLS for http api for consul. Currently when we configure ssl certs, TLS is enabled only for rpc ports but not for http. Due to this one can communicate with consul using its REST apis over http and there is no way to enable TLS for http api. This PR sets up https port when ssl certs are configured thereby enabling TLS for http api as well.