### PR TITLE
make `consul leave` work when TLS is enabled

### DIFF
--- a/jobs/consul/templates/bin/consul_ctl
+++ b/jobs/consul/templates/bin/consul_ctl
@@ -75,6 +75,12 @@ EOF
     ;;
 
   stop)
+    <% if_p("consul.ssl_ca", "consul.ssl_cert", "consul.ssl_key") do |ca, cert, key| %>
+    export CONSUL_HTTP_SSL=true
+    export CONSUL_CACERT=<%= ca %>
+    export CONSUL_CLIENT_CERT=<%= cert %>
+    export CONSUL_CLIENT_KEY=<%= key %>
+    <% end %>
     consul leave
     ;;
 


### PR DESCRIPTION
If TLS is enabled then[ port 8500 only responds to HTTPS requests, and requires a client certificate for authentication](https://github.com/cloudfoundry-community/consul-boshrelease/blob/master/jobs/consul/templates/consul/agent.json.erb#L35-L43).  

This prevents `monit stop consul` from working as [consul leave](https://github.com/cloudfoundry-community/consul-boshrelease/blob/master/jobs/consul/templates/consul/agent.json.erb#L35-L43) will attempt to communicate with the API via HTTP not HTTPS and report the following error:
 ```Error leaving: Put http://127.0.0.1:8500/v1/agent/leave: malformed HTTP response "\x15\x03\x01\x00\x02\x02"```

This PR sets the required variables for the consul CLI to properly communicate with the API over TLS when TLS is enabled.

