### PR TITLE
Add new http_local parameter for consul_ctl to use HTTP even when cer…

### DIFF
--- a/jobs/consul/spec
+++ b/jobs/consul/spec
@@ -61,6 +61,10 @@ properties:
   consul.leave_on_terminate:
     description: If enabled, gracefully leave the cluster when the process shuts down.
     default: false
+  consul.http_local:
+    description: If enabled AND when ssl_ca, ssl_cert and ssl_key are set, this toggles use of HTTP for local consul communication by scripts. This prevents failures to stop/start the service when you have configured the agent for SSL client cert authentication or are using multiple ports/addresses to listen
+    default: false
+
 
   consul.agent_config:
     description: override hash for the consul agent.json configuration

--- a/jobs/consul/templates/bin/consul_ctl
+++ b/jobs/consul/templates/bin/consul_ctl
@@ -76,10 +76,12 @@ EOF
 
   stop)
     <% if_p("consul.ssl_ca", "consul.ssl_cert", "consul.ssl_key") do %>
+      <% if !p("consul.http_local") == true %>
     export CONSUL_HTTP_SSL=true
     export CONSUL_CACERT=$JOB_DIR/consul/ca.cert
     export CONSUL_CLIENT_CERT=$JOB_DIR/consul/consul.cert
     export CONSUL_CLIENT_KEY=$JOB_DIR/consul/consul.key
+      <% end %>
     <% end %>
     /var/vcap/packages/consul/bin/consul leave
     ;;

--- a/jobs/consul/templates/bin/consul_ctl
+++ b/jobs/consul/templates/bin/consul_ctl
@@ -76,7 +76,7 @@ EOF
 
   stop)
     <% if_p("consul.ssl_ca", "consul.ssl_cert", "consul.ssl_key") do %>
-      <% if !p("consul.http_local") == true %>
+      <% if !p("consul.http_local") %>
     export CONSUL_HTTP_SSL=true
     export CONSUL_CACERT=$JOB_DIR/consul/ca.cert
     export CONSUL_CLIENT_CERT=$JOB_DIR/consul/consul.cert


### PR DESCRIPTION
This PR adds a new parameter that will disable the use of HTTPS in consul_ctl when cert/key/ca_file are set.

The automatic use of HTTPS in consul_ctl when cert/key/ca_file are specified breaks the scenario where http on localhost is preferred, but a client certificate is used to authenticate to the consul servers. Another use case is to configure http for localhost on 8500 so consul commands on-box work without any special environment variables or command line parameters, but to configure consul to listen on the machine's visible interface to listen on another port for https.

The breakage under these scenarios is straight forward - the current consul_ctl script assumes that since a cert/key/ca_file are defined, that SSL must be desired. That's usually fine, but under the two use cases above, consul CLI command will expect HTTPS, but will be actually getting HTTP. This causes the stop command of consul_ctl to fail on "consul leave" - making BOSH believe that the stop failed, thus aborting whatever action is being attempted.

P.S.
Side note - HTTPS locally + client certificate authentication would require some acrobatics:
* The cert must be signed as both a client and server cert
* The cert must be signed with a SAN IP of 127.0.0.1

These are both slightly odd requirements, so perhaps should be documented somewhere.