### PR TITLE
Support configuring wan servers

### DIFF
--- a/jobs/consul/spec
+++ b/jobs/consul/spec
@@ -74,3 +74,6 @@ properties:
 
   networks.apps:
     description: Deployment's internal name for the network interface to discover own IP
+
+  consul.wan_servers:
+    description: A list of wan hosts to be connected.

--- a/jobs/consul/templates/consul/agent.json.erb
+++ b/jobs/consul/templates/consul/agent.json.erb
@@ -52,6 +52,11 @@
     config[:encrypt] = p('consul.encrypt')
   end
 
+  if p('consul.wan_servers', nil)
+    config[:start_join_wan] = p('consul.wan_servers')
+    config[:retry_join_wan] = p('consul.wan_servers')
+  end
+
   if (networks = spec.networks.methods(false)) && dns = spec.networks.send(networks.first).dns
     config[:recursor] = dns.first
   else


### PR DESCRIPTION
This patch add support configuring wan servers in case wan_servers
property is added.

This will enable consul servers to connect to remote datacenters when
configured.